### PR TITLE
Fix audio and background assets not loading on iOS devices

### DIFF
--- a/src/reader/animation/animation.js
+++ b/src/reader/animation/animation.js
@@ -55,13 +55,6 @@ class Animation extends Component {
       audio.innerHTML =
         "<source src=\"" + file + ".ogg\" type=\"audio/ogg\"/>" +
         "<source src=\"" + file + ".m4a\" type=\"audio/mp4\"/>"
-      promises.push(new Promise(resolve => {
-        audio.oncanplaythrough = () => resolve(true)
-        audio.onerror = () => resolve(true)
-        let first = true
-        audio.firstElementChild.onerror = () => first ? (first = false) : resolve(true)
-        audio.lastElementChild.onerror = () => first ? (first = false) : resolve(true)
-      }))
       audio.preload = "auto"
       return audio
     }

--- a/src/reader/animation/animation.js
+++ b/src/reader/animation/animation.js
@@ -55,6 +55,17 @@ class Animation extends Component {
       audio.innerHTML =
         "<source src=\"" + file + ".ogg\" type=\"audio/ogg\"/>" +
         "<source src=\"" + file + ".m4a\" type=\"audio/mp4\"/>"
+
+      const ua = window.navigator.userAgent
+      if (!(ua.indexOf("iPhone") > -1 || ua.indexOf("iPad") > -1)) {
+        promises.push(new Promise(resolve => {
+          audio.oncanplaythrough = () => resolve(true)
+          audio.onerror = () => resolve(true)
+          let first = true
+          audio.firstElementChild.onerror = () => first ? (first = false) : resolve(true)
+          audio.lastElementChild.onerror = () => first ? (first = false) : resolve(true)
+        }))
+      }
       audio.preload = "auto"
       return audio
     }

--- a/src/reader/reader.js
+++ b/src/reader/reader.js
@@ -17,6 +17,18 @@ class Reader extends Component {
     this.state = {ready: false}
   }
 
+  componentDidMount() {
+    const ua = window.navigator.userAgent
+    if (ua.indexOf("iPhone") > -1 || ua.indexOf("iPad") > -1) {
+      window.addEventListener('touchstart', () => {
+        const audioTags = Array.from(document.getElementsByClassName("react-audio-player "))
+        audioTags.forEach((a) => {
+          if (!a.ended && !a.playing) a.play()
+        })
+      })
+    }
+  }
+
   render() {
     const options = this.props.options
     return (


### PR DESCRIPTION
Fixes two major bugs, one visual, and one audio, that make the site unusable on Apple devices in Safari iOS 15.

### Bug 1: Background and character assets are not loading causing a blank screen.
The reason is that the Animation [`preload`](https://github.com/Kent-H/kirikiri-web/blob/master/src/reader/animation/animation.js#L28) for the `audio` tag is crashing for some reason causing the remaining elements to not get loaded. Removing Audio promises resolves the issue. I didn't dig deeper to figure out why.

Steps to reproduce:
1. Open an iOS simulator and go to the local web page. Specific URL `http://192.168.1.96:3000/fate/2nd-day/15`
2. Scroll down a bit and should see that the background and character images do not load.
3. Use the web inspector and should see that the `audio` tag did not load in the DOM.

### Bug 2: Audio does not autoplay for iOS devices
Once the `audio` tags load into the DOM, iOS devices by default does not respect the `autoplay` attribute and [disables it](https://developer.apple.com/library/archive/documentation/AudioVideo/Conceptual/Using_HTML5_Audio_Video/Device-SpecificConsiderations/Device-SpecificConsiderations.html). There is no user control to override the setting on iOS devices. The resolution is to call `play()` on the element, but it needs to be hooked to a user initiated events like [`touchstart`](https://stackoverflow.com/a/68107904). Calling `play()` in other areas like after the `audio` tags are created will raise a permissions exception. The only caveat is that sometimes the user will need to touch the screen again for the audio to play if the audio tags load after the user touches due to slower audio files downloading on mobile, but at least it is playable.


Steps to reproduce:
1. Use the fix from above.
2. Open an iOS simulator and go to the local web page. Specific URL `http://192.168.1.96:3000/fate/2nd-day/15`
3. Scroll down a bit and should notice nothing gets played.


Before:
![Screen Shot 2022-03-06 at 3 50 30 PM](https://user-images.githubusercontent.com/6520635/156947697-c700fc06-0ad5-490d-9281-8e54179b8fb4.png)

After:
![Screen Shot 2022-03-06 at 3 51 41 PM](https://user-images.githubusercontent.com/6520635/156947747-f97a14e1-3c03-4f11-bf82-16c00aa2ddf4.png)

#### Tested devices
Tested on iOS 15 Safari on iPhone 13, iPad, and iPhone 13 simulator.
